### PR TITLE
ENH: Clean up `ISMRM2015` dataset submission data fetcher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dipy
 numpy
 nibabel
+pandas
 pytest==5.3.*
 pytest-cov
 pytest-xdist

--- a/tractodata/io/tests/test_fetcher.py
+++ b/tractodata/io/tests/test_fetcher.py
@@ -932,3 +932,184 @@ def test_read_ismrm2015_bundle_endpoint_masks():
         mask_endpoint_img = bundle_endpoint_masks[_name]
 
         _check_ismrm2015_img(mask_endpoint_img)
+
+
+def test_get_ismrm2015_submission_id_from_filenames():
+
+    fnames = [
+        "/path/to/ismrm2015_tractography_challenge_submission1-0_angular_error_results.csv",  # noqa E501
+        "/path/to/ismrm2015_tractography_challenge_submission1-1_angular_error_results.csv",  # noqa E501
+        "/path/to/ismrm2015_tractography_challenge_submission1-2_angular_error_results.csv",  # noqa E501
+        "/path/to/ismrm2015_tractography_challenge_submission2-1_angular_error_results.csv"]  # noqa E501
+    expected_val = ["1-0", "1-1", "1-2", "2-1"]
+    obtained_val = fetcher._get_ismrm2015_submission_id_from_filenames(fnames)
+
+    assert expected_val == obtained_val
+
+
+def test_classify_ismrm2015_submissions_results_files():
+
+    overall_scores_fname, angular_error_score_fnames, bundle_score_fnames = \
+        fetcher._classify_ismrm2015_submissions_results_files()
+
+    expected_val = pjoin(
+        fetcher.tractodata_home, "datasets", "ismrm2015", "derivatives",
+        "submission", "synth", "sub-02", "dwi",
+        "ismrm2015_tractography_challenge_overall_results.csv")
+    obtained_val = overall_scores_fname
+
+    assert expected_val == obtained_val
+
+    expected_val = 96
+    obtained_val = len(angular_error_score_fnames)
+
+    assert expected_val == obtained_val
+
+    expected_val = 96
+    obtained_val = len(bundle_score_fnames)
+
+    assert expected_val == obtained_val
+
+
+def test_read_ismrm2015_submissions_overall_performance_data():
+
+    df = fetcher.read_ismrm2015_submissions_overall_performance_data()
+
+    expected_val = 96
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = 6
+    obtained_val = len(df.columns)
+
+    assert expected_val == obtained_val
+
+    score = ["IB"]
+    df = fetcher.read_ismrm2015_submissions_overall_performance_data(
+        score=score)
+
+    expected_val = 96
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = score
+    obtained_val = df.columns.to_list()
+
+    assert expected_val == obtained_val
+
+
+def test_read_ismrm2015_submissions_angular_performance_data():
+
+    df = fetcher.read_ismrm2015_submissions_angular_performance_data()
+
+    expected_val = 96*3
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = 5
+    obtained_val = len(df.columns)
+
+    assert expected_val == obtained_val
+
+    score = ["Median"]
+    df = fetcher.read_ismrm2015_submissions_angular_performance_data(
+        score=score)
+
+    expected_val = 96*3
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = score
+    obtained_val = df.columns.to_list()
+
+    assert expected_val == obtained_val
+
+    roi = ["Voxels with crossing fibers"]
+    df = fetcher.read_ismrm2015_submissions_angular_performance_data(roi=roi)
+
+    expected_val = 96
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = 5
+    obtained_val = len(df.columns)
+
+    assert expected_val == obtained_val
+
+    score = ["Standard deviation"]
+    roi = ["Voxels with single fiber population"]
+    df = fetcher.read_ismrm2015_submissions_angular_performance_data(
+        score=score, roi=roi)
+
+    expected_val = 96
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = score
+    obtained_val = df.columns.to_list()
+
+    assert expected_val == obtained_val
+
+
+def test_read_ismrm2015_submissions_bundle_performance_data():
+
+    df = fetcher.read_ismrm2015_submissions_bundle_performance_data()
+
+    expected_val = 96*25
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = 4
+    obtained_val = len(df.columns)
+
+    assert expected_val == obtained_val
+
+    score = ["Overlap (% of GT)"]
+    df = fetcher.read_ismrm2015_submissions_bundle_performance_data(
+        score=score)
+
+    expected_val = 96*25
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = score
+    obtained_val = df.columns.to_list()
+
+    assert expected_val == obtained_val
+
+    bundle_name = ["Cingulum (right)"]
+    df = fetcher.read_ismrm2015_submissions_bundle_performance_data(
+        bundle_name=bundle_name)
+
+    expected_val = 96
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = 4
+    obtained_val = len(df.columns)
+
+    assert expected_val == obtained_val
+
+    score = ["Count"]
+    bundle_name = ["Uncinate Fasciculus (right)"]
+    df = fetcher.read_ismrm2015_submissions_bundle_performance_data(
+        score=score, bundle_name=bundle_name)
+
+    expected_val = 96
+    obtained_val = len(df.index)
+
+    assert expected_val == obtained_val
+
+    expected_val = score
+    obtained_val = df.columns.to_list()
+
+    assert expected_val == obtained_val

--- a/tractodata/io/tests/test_utils.py
+++ b/tractodata/io/tests/test_utils.py
@@ -5,7 +5,8 @@ import numpy.testing as npt
 
 from tractodata.io.utils import \
     (Label, get_label_value_from_filename, filter_filenames_on_value,
-     filter_list_on_list)
+     filter_list_on_list, is_subseq, is_subseq_of_any,
+     get_longest_common_subseq)
 
 
 def test_get_bundle_from_filename():
@@ -186,3 +187,60 @@ def test_filter_filenames_on_value():
     obtained_val = filter_filenames_on_value(fnames, label, value)
 
     npt.assert_equal(expected_val, obtained_val)
+
+
+def test_is_subseq():
+
+    possible_subseq = "ismrm2015_tractography_challenge"
+    seq = \
+        "ismrm2015_tractography_challenge_submission1-0_angular_error_results"
+    expected_val = True
+    obtained_val = is_subseq(possible_subseq, seq)
+
+    assert expected_val == obtained_val
+
+    possible_subseq = "ismrm2020"
+    expected_val = False
+    obtained_val = is_subseq(possible_subseq, seq)
+
+    assert expected_val == obtained_val
+
+
+def test_is_subseq_of_any():
+
+    find = "ismrm2015_tractography"
+    data = [
+        "ismrm2015_tractography_challenge_submission1-0_angular_error_results",
+        "ismrm2015_tractography_challenge_submission1-1_angular_error_results",
+        "ismrm2015_tractography_challenge_submission1-2_angular_error_results",
+        "ismrm2015_tractography_challenge_submission2-1_angular_error_results"]
+    expected_val = True
+    obtained_val = is_subseq_of_any(find, data)
+
+    assert expected_val == obtained_val
+
+    find = "ismrm2015_tractogram"
+    expected_val = False
+    obtained_val = is_subseq_of_any(find, data)
+
+    assert expected_val == obtained_val
+
+
+def test_get_longest_common_subseq():
+
+    data = [
+        "ismrm2015_tractography_challenge_submission1-0_individual_bundle_results",  # noqa E501
+        "ismrm2015_tractography_challenge_submission1-1_individual_bundle_results",  # noqa E501
+        "ismrm2015_tractography_challenge_submission1-2_individual_bundle_results",  # noqa E501
+        "ismrm2015_tractography_challenge_submission2-1_individual_bundle_results"]  # noqa E501
+    expected_val = "ismrm2015_tractography_challenge_submission"
+    obtained_val = get_longest_common_subseq(data)
+
+    assert expected_val == obtained_val
+
+    data = ["1-0_angular_error_results", "1-1_angular_error_results",
+            "1-2_angular_error_results", "1-3_angular_error_results"]
+    expected_val = "_angular_error_results"
+    obtained_val = get_longest_common_subseq(data)
+
+    assert expected_val == obtained_val

--- a/tractodata/io/utils.py
+++ b/tractodata/io/utils.py
@@ -232,3 +232,96 @@ def filter_filenames_on_value(fnames, label, value):
         fname_shortlist.extend(shortlist)
 
     return fname_shortlist
+
+
+def is_subseq(possible_subseq, seq):
+    """Determine whether the candidate string in a subsequence in the sequence.
+
+    Parameters
+    ----------
+    possible_subseq : string
+        Candidate string to be retrieved.
+    seq : string
+        Sequence where the candidate string is to be retrieved.
+
+    Returns
+    -------
+    `True` if the candidate string is contained in the data; `False` otherwise.
+    """
+
+    def _get_length_n_slices(n):
+        for i in range(len(seq) + 1 - n):
+            yield seq[i:i+n]
+
+    # Will also return True if possible_subseq == seq
+    if len(possible_subseq) > len(seq):
+        return False
+
+    for slc in _get_length_n_slices(len(possible_subseq)):
+        if slc == possible_subseq:
+            return True
+
+    return False
+
+
+def is_subseq_of_any(find, data):
+    """Determine whether the candidate string in a subsequence in all data
+    elements.
+
+    Parameters
+    ----------
+    find : string
+        Candidate string to be retrieved.
+    data : list
+        Strings from which the longest common subsequence needs to be
+        retrieved.
+
+    Returns
+    -------
+    `True` if the candidate string is contained in all data elements; `False`
+    otherwise.
+    """
+
+    if len(data) < 1 and len(find) < 1:
+        return False
+    for i in range(len(data)):
+        if not is_subseq(find, data[i]):
+            return False
+
+    return True
+
+
+# ToDo
+# These seem to have O(M*N) and apparently there are more efficient solutions
+# using suffix trees (O(m+n)) or similar implementations (note that this may
+# require # substrings other than a suffix) or difflib.
+# Further references:
+# https://stackoverflow.com/questions/40556491/how-to-find-the-longest-common-substring-of-multiple-strings
+# https://stackoverflow.com/questions/18715688/find-common-substring-between-two-strings
+# or else, os.path.commonprefix
+#
+def get_longest_common_subseq(data):
+    """Get longest common subsequence (starting from the beginning) across the
+    given data.
+
+    Parameters
+    ----------
+    data : list
+        Strings from which the longest common subsequence needs to be
+        retrieved.
+
+    Returns
+    -------
+    substr : string
+        The retrieved longest common subsequence.
+    """
+
+    substr = []
+
+    if len(data) > 1 and len(data[0]) > 0:
+        for i in range(len(data[0])):
+            for j in range(len(data[0])-i+1):
+                if j > len(substr) and is_subseq_of_any(data[0][i:i+j], data):
+                    substr = data[0][i:i+j]
+
+    return substr


### PR DESCRIPTION
Clean up `ISMRM2015` dataset submission data fetcher:
- Add the corresponding entry in the `Dataset` enum.
- Remove the unnecessary filename list given that files will be contained in a
  compressed file.
- Complete the rest of the submission data fetcher information (local path, URL,
  hash, size).
- Add methods to read the overall, angular, and bundle performance data.
- Add the accompanying helper methods.
- Add the relevant `utils` methods.
- Add the relevant tests.
- Add `pandas` to the requirements file.