### PR TITLE
ENH: Switch artifact upload action branch to `main`

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -56,7 +56,7 @@ jobs:
         coverage run --source tractodata -m pytest tractodata -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}
         path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml


### PR DESCRIPTION
Switch artifact upload action branch to new default name `main`.