### PR TITLE
ENH: Add `ISMRM2015` surface data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest==5.3.*
 pytest-cov
 pytest-xdist
 pytest-pep8
+trimeshpy==0.0.2

--- a/tractodata/io/tests/test_utils.py
+++ b/tractodata/io/tests/test_utils.py
@@ -112,6 +112,17 @@ def test_get_tissue_from_filename():
     assert expected_val == obtained_val
 
 
+def test_get_surface_from_filename():
+
+    fname = "/dir/subdir/sub01-T1w_hemi-R_space-orig_pial.surf.vtk"
+
+    expected_val = "pial"
+    obtained_val = get_label_value_from_filename(
+        fname, Label.SURFACE, has_period=True)
+
+    assert expected_val == obtained_val
+
+
 def test_filter_list_on_list():
 
     primary_list = ["subset-CC", "subset-Cing", "subset-CST"]


### PR DESCRIPTION
Add `ISMRM2015` surface data.

Add the necessary accompanying methods to list and read surface datasets.

Add the necessary helpert methods and modify the existing ones to account for
the naming used by surface files.

Add `trimeshpy` to the package requirements file.