### PR TITLE
ENH: Check tractogram class in `FiberCup` local prob track bundling test

### DIFF
--- a/tractodata/io/tests/test_fetcher.py
+++ b/tractodata/io/tests/test_fetcher.py
@@ -698,6 +698,9 @@ def test_read_fibercup_local_prob_bundling():
     obtained_val = len(bundles["bundle3"])
     assert expected_val == obtained_val
 
+    npt.assert_equal(
+        bundles["bundle3"].__class__.__name__, StatefulTractogram.__name__)
+
 
 def test_read_ismrm2015_anat():
 


### PR DESCRIPTION
 Check tractogram class in `FiberCup` local prob track bundling test.