### PR TITLE
ENH: Add MNI ICBM 2009c nonlinear symmetric template data

### DIFF
--- a/tractodata/io/tests/test_fetcher.py
+++ b/tractodata/io/tests/test_fetcher.py
@@ -104,6 +104,14 @@ def _check_ismrm2015_img(img):
     npt.assert_equal(img.get_fdata().shape, (180, 216, 180))
 
 
+def _check_mni2009cnonlinsymm_img(img):
+
+    npt.assert_equal(
+        img.__class__.__name__, nib.Nifti1Image.__name__)
+    npt.assert_equal(img.get_fdata().dtype, np.float64)
+    npt.assert_equal(img.get_fdata().shape, (193, 229, 193))
+
+
 def test_check_hash():
 
     _, fname = tempfile.mkstemp()
@@ -1253,4 +1261,88 @@ def test_read_ismrm2015_submissions_bundle_performance_data():
     expected_val = score
     obtained_val = df.columns.to_list()
 
+    assert expected_val == obtained_val
+
+
+def fetch_mni2009cnonlinsymm_anat():
+
+    anat_img = fetcher.read_dataset_anat(Dataset.MNI2009CNONLINSYMM_ANAT.name)
+
+    _check_mni2009cnonlinsymm_img(anat_img)
+
+
+def fetch_mni2009cnonlinsymm_surfaces():
+
+    surfaces = fetcher.read_dataset_surfaces(
+        Dataset.MNI2009CNONLINSYMM_SURFACES.name)
+
+    expected_val = 2
+    obtained_val = len(surfaces)
+    assert expected_val == obtained_val
+
+    as_polydata = False
+    surface_type = ["pial"]
+    hemisphere_name = "L"
+    surface = fetcher.read_dataset_surfaces(
+        Dataset.MNI2009CNONLINSYMM_SURFACES.name, surface_type=surface_type,
+        hemisphere_name=hemisphere_name, as_polydata=as_polydata)
+
+    _name = fetcher._build_surface_key(
+        surface_type[0], hemisphere=hemisphere_name)
+
+    expected_val = 308894
+    obtained_val = surface[_name].get_nb_triangles()
+    assert expected_val == obtained_val
+
+    expected_val = 154449
+    obtained_val = surface[_name].get_nb_vertices()
+    assert expected_val == obtained_val
+
+    hemisphere_name = "R"
+    surface = fetcher.read_dataset_surfaces(
+        Dataset.MNI2009CNONLINSYMM_SURFACES.name, surface_type=surface_type,
+        hemisphere_name=hemisphere_name, as_polydata=as_polydata)
+
+    _name = fetcher._build_surface_key(
+        surface_type[0], hemisphere=hemisphere_name)
+
+    expected_val = 309130
+    obtained_val = surface[_name].get_nb_triangles()
+    assert expected_val == obtained_val
+
+    expected_val = 154567
+    obtained_val = surface[_name].get_nb_vertices()
+    assert expected_val == obtained_val
+
+    as_polydata = True
+    hemisphere_name = "L"
+    surface = fetcher.read_dataset_surfaces(
+        Dataset.MNI2009CNONLINSYMM_SURFACES.name, surface_type=surface_type,
+        hemisphere_name=hemisphere_name, as_polydata=as_polydata)
+
+    _name = fetcher._build_surface_key(
+        surface_type[0], hemisphere=hemisphere_name)
+
+    expected_val = (308894, 3)
+    obtained_val = vtk_u.get_polydata_triangles(surface[_name]).shape
+    assert expected_val == obtained_val
+
+    expected_val = (154449, 3)
+    obtained_val = vtk_u.get_polydata_vertices(surface[_name]).shape
+    assert expected_val == obtained_val
+
+    hemisphere_name = "R"
+    surface = fetcher.read_dataset_surfaces(
+        Dataset.MNI2009CNONLINSYMM_SURFACES.name, surface_type=surface_type,
+        hemisphere_name=hemisphere_name, as_polydata=as_polydata)
+
+    _name = fetcher._build_surface_key(
+        surface_type[0], hemisphere=hemisphere_name)
+
+    expected_val = (309130, 3)
+    obtained_val = vtk_u.get_polydata_triangles(surface[_name]).shape
+    assert expected_val == obtained_val
+
+    expected_val = (154567, 3)
+    obtained_val = vtk_u.get_polydata_vertices(surface[_name]).shape
     assert expected_val == obtained_val


### PR DESCRIPTION
Add MNI ICBM 2009c nonlinear symmetric template data:
- Brain-masked T1w data.
- Surface data computed from the brain-masked T1w data.