### PR TITLE
 BUG: Rename MNI ICBM 2009c nonlinear symmetric template dataset tests

### DIFF
--- a/tractodata/io/tests/test_fetcher.py
+++ b/tractodata/io/tests/test_fetcher.py
@@ -1264,14 +1264,14 @@ def test_read_ismrm2015_submissions_bundle_performance_data():
     assert expected_val == obtained_val
 
 
-def fetch_mni2009cnonlinsymm_anat():
+def test_read_mni2009cnonlinsymm_anat():
 
     anat_img = fetcher.read_dataset_anat(Dataset.MNI2009CNONLINSYMM_ANAT.name)
 
     _check_mni2009cnonlinsymm_img(anat_img)
 
 
-def fetch_mni2009cnonlinsymm_surfaces():
+def test_read_mni2009cnonlinsymm_surfaces():
 
     surfaces = fetcher.read_dataset_surfaces(
         Dataset.MNI2009CNONLINSYMM_SURFACES.name)


### PR DESCRIPTION
Rename MNI ICBM 2009c nonlinear symmetric template dataset tests to:
- Avoid collisions with the corresponding fetcher definitions in
  `tractodata.io.fetcher`.
- Honor their purpose.
- Make them consistent with the rest of the naming convention.