### PR TITLE
ENH: Add tracking evaluation config files

### DIFF
--- a/tractodata/io/fetcher.py
+++ b/tractodata/io/fetcher.py
@@ -2,6 +2,7 @@
 
 import enum
 import itertools
+import json
 import os
 import subprocess
 import sys
@@ -66,6 +67,7 @@ class Dataset(enum.Enum):
     FIBERCUP_DIFFUSION_PEAKS = "fibercup_diffusion_peaks"
     FIBERCUP_LOCAL_PROB_TRACKING = "fibercup_local_prob_tracking"
     FIBERCUP_LOCAL_PROB_BUNDLING = "fibercup_local_prob_bundling"
+    FIBERCUP_TRACKING_EVALUATION_CONFIG = "fibercup_tracking_evaluation_config"
     # ISBI2013_ANAT = "isbi2013_anat"
     # ISBI2013_DWI = "isbi2013_dwi"
     # ISBI2013_TRACTOGRAPHY = "isbi2013_tractography"
@@ -78,6 +80,7 @@ class Dataset(enum.Enum):
     ISMRM2015_BUNDLE_MASKS = "ismrm2015_bundle_masks"
     ISMRM2015_BUNDLE_ENDPOINT_MASKS = "ismrm2015_bundle_endpoint_masks"
     ISMRM2015_CHALLENGE_SUBMISSION = "ismrm2015_challenge_submission"
+    ISMRM2015_TRACKING_EVALUATION_CONFIG = "ismrm2015_tracking_evaluation_config"  # noqa E501
     MNI2009CNONLINSYMM_ANAT = "mni2009cnonlinsymm_anat"
     MNI2009CNONLINSYMM_SURFACES = "mni2009cnonlinsymm_surfaces"
 
@@ -593,6 +596,19 @@ fetch_fibercup_local_prob_bundling = _make_fetcher(
     unzip=True
     )
 
+fetch_fibercup_tracking_evaluation_config = _make_fetcher(
+    "fetch_fibercup_tracking_evaluation_config",
+    pjoin(tractodata_home, "datasets", "fibercup", "derivatives", "scoring",
+          "dwi"),
+    TRACTODATA_DATASETS_URL + "r3h54/",
+    ["download"],
+    ["tracking_evaluation_config.json"],
+    ["6399cb13a9600acee1ad8fe69437a5af"],
+    data_size="917B",
+    doc="Download Fiber Cup dataset tracking evaluation config file",
+    unzip=False
+    )
+
 fetch_isbi2013_anat = _make_fetcher(
     "fetch_isbi2013_anat",
     pjoin(tractodata_home, "datasets", "isbi2013", "raw", "sub-01", "anat"),
@@ -718,21 +734,6 @@ fetch_ismrm2015_synth_bundling = _make_fetcher(
     unzip=True
     )
 
-fetch_ismrm2015_qb = _make_fetcher(
-    "fetch_ismrm2015_qb",
-    pjoin(
-        tractodata_home, "datasets", "ismrm2015", "derivatives", "qb",
-        "sub-01", "dwi"),
-    TRACTODATA_DATASETS_URL + "datasets/" + "ismrm2015/" + "derivatives/" +
-    "qb/" + "sub-01/" + "dwi/",
-    ["bundles_attributes.json"],
-    ["bundles_attributes.json"],
-    ["file1_SHA"],
-    data_size="12KB",
-    doc="Download ISMRM 2015 Tractography Challenge QuickBundles centroid config data",  # noqa E501
-    unzip=True
-    )
-
 fetch_ismrm2015_bundle_masks = _make_fetcher(
     "fetch_ismrm2015_bundle_masks",
     pjoin(
@@ -773,6 +774,19 @@ fetch_ismrm2015_submission_res = _make_fetcher(
     data_size="116.8KB",
     doc="Download ISMRM 2015 Tractography Challenge submission result data",
     unzip=True
+    )
+
+fetch_ismrm2015_tracking_evaluation_config = _make_fetcher(
+    "fetch_ismrm2015_tracking_evaluation_config",
+    pjoin(tractodata_home, "datasets", "ismrm2015", "derivatives", "scoring",
+          "dwi"),
+    TRACTODATA_DATASETS_URL + "wbdyr/",
+    ["download"],
+    ["tracking_evaluation_config.json"],
+    ["164489da0dc4fb069212543c669ba284"],
+    data_size="1.4KB",
+    doc="Download ISMRM 2015 Tractography Challenge dataset tracking evaluation config file",  # noqa E501
+    unzip=False
     )
 
 fetch_mni2009cnonlinsymm_anat = _make_fetcher(
@@ -863,6 +877,9 @@ def get_fnames(name):
         fnames = files[
             'sub01-dwi_space-orig_desc-PROB_subset-bundles_tractography.zip'][2]  # noqa E501
         return sorted([pjoin(folder, f) for f in fnames])
+    elif name == Dataset.FIBERCUP_TRACKING_EVALUATION_CONFIG.name:
+        files, folder = fetch_fibercup_tracking_evaluation_config()
+        return pjoin(folder, list(files.keys())[0])
     # elif name == Dataset.ISBI2013_ANAT.name:
     #   files, folder = fetch_isbi2013_anat()
     #   return pjoin(folder, list(files.keys())[0])  # "T1w.nii.gz")
@@ -914,6 +931,9 @@ def get_fnames(name):
         fnames = files[
             'sub02-dwi_space-orig_desc-synth_submission_results_tractography.zip'][2]  # noqa E501
         return sorted([pjoin(folder, f) for f in fnames])
+    elif name == Dataset.ISMRM2015_TRACKING_EVALUATION_CONFIG.name:
+        files, folder = fetch_ismrm2015_tracking_evaluation_config()
+        return pjoin(folder, list(files.keys())[0])
     elif name == Dataset.MNI2009CNONLINSYMM_ANAT.name:
         files, folder = fetch_mni2009cnonlinsymm_anat()
         fnames = files['sub01-T1w.zip'][2]
@@ -1409,6 +1429,28 @@ def read_dataset_diffusion_peaks(name):
     fname = get_fnames(name)
 
     return nib.load(fname)
+
+
+def read_dataset_tracking_evaluation_config(name):
+    """Load dataset tracking evaluation configuration data.
+
+    Parameters
+    ----------
+    name : string
+        Dataset name.
+
+    Returns
+    -------
+    config : dict
+        Tracking evaluation configuration data.
+    """
+
+    _check_known_dataset(name)
+
+    fname = get_fnames(name)
+
+    with open(fname, 'r') as f:
+        return json.load(f)
 
 
 def _get_ismrm2015_submission_id_from_filenames(fnames):

--- a/tractodata/io/tests/test_fetcher.py
+++ b/tractodata/io/tests/test_fetcher.py
@@ -38,6 +38,8 @@ ismrm2015_commissural_bundles = ["CC", "CA", "CP", "Fornix", "MCP"]
 ismrm2015_tissues = [Tissue.WM.value]
 ismrm2015_surfaces = [Surface.PIAL.value]
 
+tracking_config_file_necessary_keys = ["cluster_threshold"]
+
 
 def _build_fibercup_bundle_endpoints():
 
@@ -110,6 +112,12 @@ def _check_mni2009cnonlinsymm_img(img):
         img.__class__.__name__, nib.Nifti1Image.__name__)
     npt.assert_equal(img.get_fdata().dtype, np.float64)
     npt.assert_equal(img.get_fdata().shape, (193, 229, 193))
+
+
+def _check_tracking_evaluation_config(config):
+
+    for key, val in config.items():
+        assert set(tracking_config_file_necessary_keys) <= val.keys()
 
 
 def test_check_hash():
@@ -731,6 +739,20 @@ def test_read_fibercup_local_prob_bundling():
         bundles["bundle3"].__class__.__name__, StatefulTractogram.__name__)
 
 
+def test_read_fibercup_tracking_evaluation_config():
+
+    tracking_evaluation_config = \
+        fetcher.read_dataset_tracking_evaluation_config(
+            Dataset.FIBERCUP_TRACKING_EVALUATION_CONFIG.name)
+
+    expected_val = len(fibercup_bundles)
+    obtained_val = len(tracking_evaluation_config)
+
+    assert expected_val == obtained_val
+
+    _check_tracking_evaluation_config(tracking_evaluation_config)
+
+
 def test_read_ismrm2015_anat():
 
     anat_img = fetcher.read_dataset_anat(Dataset.ISMRM2015_ANAT.name)
@@ -1283,6 +1305,20 @@ def test_read_ismrm2015_submissions_bundle_performance_data():
     obtained_val = df.columns.to_list()
 
     assert expected_val == obtained_val
+
+
+def test_read_ismrm2015_tracking_evaluation_config():
+
+    tracking_evaluation_config = \
+        fetcher.read_dataset_tracking_evaluation_config(
+            Dataset.ISMRM2015_TRACKING_EVALUATION_CONFIG.name)
+
+    expected_val = 25
+    obtained_val = len(tracking_evaluation_config)
+
+    assert expected_val == obtained_val
+
+    _check_tracking_evaluation_config(tracking_evaluation_config)
 
 
 def test_read_mni2009cnonlinsymm_anat():


### PR DESCRIPTION
Add tracking evaluation config files for the `FiberCup` and `ISMRM2015`
datasets.