### PR TITLE
ENH: Add automatic code formatting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+default_language_version:
+  python: python3.6
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-added-large-files
+        name: check-added-large-files
+        description: Prevent giant files from being committed.
+      - id: check-ast
+        name: check-ast
+        description: Simply check whether files parse as valid python.
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+        name: check-merge-conflict
+        description: Check for files that contain merge conflict strings.
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+        name: requirements-txt-fixer
+        description: Sorts entries in requirements.txt
+      - id: trailing-whitespace
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort
+        args: [--settings-path, ./pyproject.toml]
+        types: [python]
+
+  - repo: https://github.com/psf/black
+    rev: 21.5b1
+    hooks:
+      - id: black
+        name: black
+        args: [--config, ./pyproject.toml]
+        types: [python]
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        name: flake8
+        additional_dependencies: [flake8-docstrings==1.6.0]
+        args: [--config, ./setup.cfg]
+        types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+title = "tractodata TOML configuration file"
+
+# Code formatting configuration
+
+[tool.black]
+line-length = 79
+target-version = ["py36"]
+exclude ='''
+(
+  /(
+      \.eggs        # exclude a few common directories in the
+    | \.git         # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | data            # also separately exclude project-specific files
+                    # and folders in the root of the project
+)
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 79
+src_paths = ["tractodata"]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,3 +1,8 @@
+black==21.5b1
+flake8==3.9.2
+flake8-docstrings==1.6.0
+isort==5.8.0
+pre-commit>=2.9.0
 pytest==5.3.*
 pytest-cov
 pytest-xdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,21 @@
+[flake8]
+max-line-length = 79
+doctests = True
+docstring-convention = numpy
+exclude = .tox,*.egg,build,temp
+verbose = 2
+# https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+format = pylint
+ignore =
+    # D100,  # D100 - missing docstring in public module
+    # D104,  # D104 - missing docstring in public package
+    # D107,  # D107 - missing docstring in __init__
+    D,     # Ignore all docstrings
+    E203,  # E203 - whitespace before ':'. Opposite convention enforced by black
+    E231,  # E231 - missing whitespace after ',', ';', or ':'; for black
+    E501,  # E501 - line too long. Handled by black, we have longer lines
+    W503   # W503 - line break before binary operator, need for black
+extend-ignore =
+    D103   ./* # D103 - missing docstring in public function
+extend-select =
+    D404  # D404 - first word of the docstring should not be `This`


### PR DESCRIPTION
Add automatic code formatting tools using the `pre-commit` Python package.

This Python package uses the configuration options in the
`.pre-commit-config.yaml` file, and makes use of the specified repositories to
configure the desired pre-commit hooks. At the same time, these pre-commit hooks
read the corresponding configuration options from other files added in this
commit.

Add the necessary packages to the development requirements file.