### PR TITLE
ENH: Add code format check `GitHub` action workflow file

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -1,0 +1,25 @@
+name: check code format
+
+on: [push]
+
+jobs:
+  pre-commit:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04]
+        python-version: [3.6]
+        requires: ['latest']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+      - name: Install and run pre-commit hooks
+        uses: pre-commit/action@v2.0.0

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -48,13 +48,10 @@ jobs:
         pip --version
         pip list
 
-    - name: Lint and Tests
+    - name: Run tests
       run: |
         # tox --sitepackages
-        pip install flake8==3.7.9
-        flake8 --version
         python -c 'import tractodata'
-        flake8 . --count --statistics
         coverage run --source tractodata -m pytest tractodata -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
         description: Check for files that contain merge conflict strings.
       - id: check-toml
       - id: check-yaml
+        exclude: .github/workflows/*
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: requirements-txt-fixer

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # tractodata
 
 
-[![Build Status](https://github.com/jhlegarreta/tractodata/actions/workflows/test_package.yml/badge.svg?branch=main)](https://github.com/jhlegarreta/tractodata/actions/workflows/test_package.yml?query=branch%3Amain)
+[![Build status](https://github.com/jhlegarreta/tractodata/actions/workflows/test_package.yml/badge.svg?branch=main)](https://github.com/jhlegarreta/tractodata/actions/workflows/test_package.yml?query=branch%3Amain)
+[![Code format](https://github.com/jhlegarreta/tractodata/actions/workflows/check_format.yml/badge.svg?branch=dev)](https://github.com/jhlegarreta/tractodata/actions/workflows/check_format.yml?query=branch%3Amain)
 
 Tractography data.
 


### PR DESCRIPTION
Add a code formatting check `GitHub` action workflow file.

As a consequence, remove the `flake8` code checking task from the `test,
package` workflow file.

Take advantage of the commit to exclude `GitHub` actions workflow files from
being checked by the `check-yaml` hook due to the fact that these files might
have some expressions to set variables (e.g. `${{ <expression> }}`) that are not
correctly interpreted by the hook.

Add the corresponding badge to the `README` file.

Take advantage of the commit to change the name of the `Build status` badge in
the `README` file.