### PR TITLE
ENH: Fix glob vs. regex warning in `check-yaml` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         description: Check for files that contain merge conflict strings.
       - id: check-toml
       - id: check-yaml
-        exclude: .github/workflows/*
+        exclude: .github/workflows
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: requirements-txt-fixer


### PR DESCRIPTION
Fix glob vs. regex warning in `check-yaml` pre-commit hook.

Fixes:
```
[WARNING] The 'exclude' field in hook 'check-yaml' is a regex, not a glob --
matching '/*' probably isn't what you want here
```

raised for example in
https://github.com/jhlegarreta/tractodata/runs/2789260106?check_suite_focus=true#step:4:60