### PR TITLE
ENH: Transition workflows to Ubuntu 20.04

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
         python-version: [3.8]
         requires: ['latest']
 

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -39,7 +39,7 @@ jobs:
           ${{ env.pythonLocation }}-
 
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
+      # if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --user pip
         pip install -r requirements/requirements.txt

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       # max-parallel: 6
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
         python-version: [3.8]
         requires: ['minimal', 'latest']
 


### PR DESCRIPTION
Transition workflows to Ubuntu 20.04.

The `ubuntu-latest` YAML workflow label implies `20.04` currently:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources