### PR TITLE
ENH: Comment `Cache pip` step in `test, package` workflow

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -28,15 +28,15 @@ jobs:
       run: |
         python -c "req = open('requirements/requirements.txt').read().replace('>', '=') ; open('requirements/requirements.txt', 'w').write(req)"
 
-    - name: Cache pip
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: ${{ env.pythonLocation }}
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/*') }}
-        restore-keys: |
-          ${{ env.pythonLocation }}-
+    #- name: Cache pip
+    #  uses: actions/cache@v2
+    #  id: cache
+    #  with:
+    #    path: ${{ env.pythonLocation }}
+    #    # Look to see if there is a cache hit for the corresponding requirements file
+    #    key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/*') }}
+    #    restore-keys: |
+    #      ${{ env.pythonLocation }}-
 
     - name: Install dependencies
       # if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Comment `Cache pip` step in `test, package` workflow to force installing
packages across runs.