### PR TITLE
STYLE: Improve extra requirements listing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = False
 packages = find:
 python_requires = >=3.6
 include_package_data = True
-install_requires  =
+install_requires =
     dipy
     nibabel
     numpy
@@ -28,16 +28,18 @@ install_requires  =
 
 [options.extras_require]
 testing =
-    black == 21.5b1
-    flake8 == 3.9.2
-    flake8-docstrings == 1.6.0
     hypothesis >= 6.8.0
-    isort == 5.8.0
-    pre-commit >= 2.9.0
     pytest == 5.3.*
     pytest-cov
     pytest-pep8
     pytest-xdist
+dev =
+    black == 21.5b1
+    flake8 == 3.9.2
+    flake8-docstrings == 1.6.0
+    isort == 5.8.0
+    pre-commit >= 2.9.0
+    %(testing)s
 
 [flake8]
 max-line-length = 79


### PR DESCRIPTION
Improve extra requirements listing: split the `testing` into `dev` and
`testing` so that when package testing is run with `tox` only the latter
dependencies get installed.