### PR TITLE
ENH: Update `ISMRM2015` submission data

### DIFF
--- a/tractodata/io/fetcher.py
+++ b/tractodata/io/fetcher.py
@@ -1121,8 +1121,8 @@ fetch_ismrm2015_submission_res = _make_fetcher(
     TRACTODATA_DATASETS_URL + "t4m9a/",
     ["download"],
     ["sub02-dwi_space-orig_desc-synth_submission_results_tractography.zip"],
-    ["6f27a599ac4977a5a91f9111c1726665"],
-    data_size="116.8KB",
+    ["41fc57fe116f8b0771fe7e38de1ab4c3"],
+    data_size="171.2KB",
     doc="Download ISMRM 2015 Tractography Challenge submission result data",
     unzip=True,
 )


### PR DESCRIPTION
Update `ISMRM2015` submission data.

The previous data, obtained by copying the data available under the form of dynamic tables in the former version of the `tractometer` website, contained errors due to oversights from the authors. Thus, none of the scores corresponded faithfully to the submissions and the published Nature Communications paper.

Part of the original data, corresponding to the bundle-wise and global bundle-related scores, faithful to the submissions, was retrieved and made available by members of the SCIL lab in September, 2022. Yet, the angular data was not retrieved/made available with that release, so the old data is kept around for the individual submission files, and an "NA" value is added for the global data until the data is retrieved.

See: https://tractometer.org/ismrm2015/results/