### PR TITLE
BUG: Update `pre-commit` action version

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -22,4 +22,4 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install and run pre-commit hooks
-      uses: pre-commit/action@v2.0.0
+      uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
Update `pre-commit` action version.

Fixes:
```
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo6xs26fy3/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repo6xs26fy3/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1055, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repo6xs26fy3/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1044, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repo6xs26fy3/py_env-python3/lib/python3.8/site-packages/click/__init__.py)
```

raised for example in:
https://github.com/jhlegarreta/tractodata/runs/8239082181?check_suite_focus=true#step:4:95