### PR TITLE
BUG: Update `pre-commit` hook `black` package version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.3.0
     hooks:
       - id: black
         name: black

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ name = tractodata
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     dipy


### PR DESCRIPTION
- ENH: Require Python >= 3.8
- BUG: Update `pre-commit` hook `black` package version