### PR TITLE
ENH: Fix `Node.js` warnings linked to GitHub `pre-commit` actions

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -22,4 +22,4 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install and run pre-commit hooks
-      uses: pre-commit/action@v2.0.3
+      uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Fix `Node.js` warnings linked to GitHub `pre-commit` actions: transition to `pre-commit/action@v3.0.0`.

Fixes:
```
pre-commit (ubuntu-latest, 3.8, latest)
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: pre-commit/action@v2.0.3
```

raised for example in:
https://github.com/jhlegarreta/tractodata/actions/runs/3669686386

Follow-up of a2c5155.