### PR TITLE
COMP: Switch to the standard library to create temporary directories

### DIFF
--- a/tractodata/io/tests/test_fetcher.py
+++ b/tractodata/io/tests/test_fetcher.py
@@ -15,7 +15,6 @@ import nibabel as nib
 import numpy as np
 import numpy.testing as npt
 from dipy.io.streamline import StatefulTractogram
-from nibabel.tmpdirs import TemporaryDirectory
 from trimeshpy import vtk_util as vtk_u
 
 import tractodata.io.fetcher as fetcher
@@ -190,7 +189,7 @@ def test_check_hash():
 def test_make_fetcher():
 
     # Make a fetcher with some test data using a local server
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
 
         test_data = TEST_FILES["fibercup_T1w"]
         name = "fetch_fibercup_test_data"
@@ -248,7 +247,7 @@ def test_make_fetcher():
         os.chdir(current_dir)
 
     # Make a fetcher with actual data storage
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
 
         name = "fetch_fibercup_dwi"
         remote_fnames = ["download"]
@@ -296,7 +295,7 @@ def test_make_fetcher():
 def test_fetch_data():
 
     # Fetch some test data using a local server
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
 
         test_data = TEST_FILES["fibercup_T1w"]
 


### PR DESCRIPTION
Switch to the standard library to create temporary directories.

It removes the additional dependency on `nibabel` used previously.

Fixes:
```
tractodata/io/tests/test_fetcher.py::test_make_fetcher
/home/runner/work/tractodata/tractodata/tractodata/io/tests/test_fetcher.py:193:
DeprecationWarning: Please use the standard library tempfile.TemporaryDirectory

  * deprecated from version: 5.0
  * Will raise <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 7.0
    with TemporaryDirectory() as tmpdir:
```

raised for example at
https://github.com/jhlegarreta/tractodata/actions/runs/3976966484/jobs/6817774895#step:6:73