### PR TITLE
 ENH: Upgrade isort to version 5.11.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.8.0
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "black == 21.5b1",
     "flake8 == 3.9.2",
     "flake8-docstrings == 1.6.0",
-    "isort == 5.8.0",
+    "isort == 5.11.5",
     "pre-commit >= 2.9.0",
 ]
 


### PR DESCRIPTION
Upgrade `isort` to version `5.11.5`.

Fixes:
```
RuntimeError: The Poetry configuration is invalid:
  - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

reported in
https://github.com/jhlegarreta/tractodata/actions/runs/4106280678/jobs/7084301519#step:4:153