### PR TITLE
ENH: Relax required `trimeshpy` dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
 dependencies = [
     "dipy",
     "nibabel",
-    "numpy",
+    "numpy < 2.0.0",
     "pandas",
-    "trimeshpy == 0.0.2",
+    "trimeshpy >= 0.0.2",
     "tqdm",
 ]
 description = "Tractography data repository to be used for tractography research"


### PR DESCRIPTION
Relax required `trimeshpy` dependency version so that more recent versions are allowed: do not pin to version `0.0.2` and allow versions equal to or greater than `0.0.2`.

The changes in the `trimeshpy` classes used in `tractodata` between versions `0.0.2` and `0.0.3` (latest release) are safe and do not affect the behavior: they only drop checks for `VTK` <= 5 and 8, adopt keyword arguments in some calls, use Python built-in types (e.g. `int` instead of `np.int`), use `NiBabel`'s `affine` property on NIfTI images, and drop import from `future`.

Restrict `NumPy` to versions lower than `2.0.0` to avoid:
```
E   ImportError: numpy.core.multiarray failed to import
 (auto-generated because you didn't call 'numpy.import_array()'
 after cimporting numpy; use '<void>numpy._import_array'
 to disable if you are certain you don't need it).

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.1.3 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

```